### PR TITLE
Add visible Telegram link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -24,4 +24,5 @@ enableToc: true
 
 Если вы хотите связаться со мной в Telegram, просто отсканируйте следующий QR-код или нажмите на него, чтобы открыть мой профиль напрямую
 [![Мой Telegram QR-код](contact/telegram_qrcode.png)](https://t.me/PetaFlops)
+[https://t.me/PetaFlops](https://t.me/PetaFlops)
 

--- a/content/contact/telegram.md
+++ b/content/contact/telegram.md
@@ -1,2 +1,3 @@
 Если вы хотите связаться со мной в Telegram, просто отсканируйте следующий QR-код или нажмите на него, чтобы открыть мой профиль напрямую
 [![Мой Telegram QR-код](contact/telegram_qrcode.png)](https://t.me/PetaFlops)
+[https://t.me/PetaFlops](https://t.me/PetaFlops)


### PR DESCRIPTION
## Summary
- add Telegram link under QR code on the home page
- add Telegram link under QR code on the contact page

## Testing
- `hugo version` *(fails: command not found)*