### PR TITLE
feat: add link verification script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",
     "test": "tsx --test",
+    "link-check": "tsx scripts/link-check.ts",
     "profile": "0x -D prof ./quartz/bootstrap-cli.mjs build --concurrency=1"
   },
   "engines": {

--- a/scripts/link-check.ts
+++ b/scripts/link-check.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process"
+
+async function startQuartz() {
+  const proc = spawn("npx", ["quartz", "build", "--serve"], {
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+  proc.stdout.setEncoding("utf-8")
+  proc.stderr.setEncoding("utf-8")
+
+  await new Promise<void>((resolve, reject) => {
+    const onData = (data: string) => {
+      process.stdout.write(data)
+      if (data.includes("Started a Quartz server")) {
+        proc.stdout.off("data", onData)
+        resolve()
+      }
+    }
+    proc.stdout.on("data", onData)
+    proc.stderr.on("data", (d) => process.stderr.write(d))
+    proc.once("error", reject)
+    proc.once("exit", (code) => reject(new Error(`quartz exited with code ${code}`)))
+  })
+
+  return proc
+}
+
+async function crawl(base: string) {
+  const visited = new Set<string>()
+  const broken: Array<{ url: string; status: number }> = []
+
+  async function visit(url: string): Promise<void> {
+    if (visited.has(url)) return
+    visited.add(url)
+    try {
+      const res = await fetch(url)
+      if (!res.ok) {
+        broken.push({ url, status: res.status })
+        return
+      }
+      const html = await res.text()
+      const regex = /href="(.*?)"/g
+      let match: RegExpExecArray | null
+      while ((match = regex.exec(html)) !== null) {
+        const href = match[1]
+        if (
+          href.startsWith("#") ||
+          href.startsWith("mailto:") ||
+          href.startsWith("javascript:")
+        ) {
+          continue
+        }
+        const resolved = new URL(href, url).href
+        if (resolved.startsWith(base)) {
+          await visit(resolved)
+        }
+      }
+    } catch {
+      broken.push({ url, status: -1 })
+    }
+  }
+
+  await visit(base)
+  return broken
+}
+
+async function main() {
+  const proc = await startQuartz()
+  const base = "http://localhost:8080/"
+  const broken = await crawl(base)
+  proc.kill()
+
+  if (broken.length > 0) {
+    console.error("Broken links found:")
+    for (const b of broken) {
+      console.error(`${b.url} => ${b.status}`)
+    }
+    process.exit(1)
+  } else {
+    console.log("No broken links found.")
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add script to run Quartz server and crawl for broken links
- expose the script via `npm run link-check`

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: missing type declarations)*
- `npm run link-check` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0596fb75c8325a239eb00e4806e2f