### PR TITLE
feat: serve custom styles from assets

### DIFF
--- a/assets/styles/custom.scss
+++ b/assets/styles/custom.scss
@@ -1,0 +1,14 @@
+@use "../../quartz/styles/base.scss";
+
+// put your custom CSS here!
+.label-icon {
+    font-size: 48px;
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+.label-text {
+    fill: white;
+    font-size: 19px;
+    text-anchor: middle;
+    dominant-baseline: middle;
+}

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -5,7 +5,7 @@ import { QuartzEmitterPlugin } from "../types"
 import spaRouterScript from "../../components/scripts/spa.inline"
 // @ts-ignore
 import popoverScript from "../../components/scripts/popover.inline"
-import styles from "../../styles/custom.scss"
+import styles from "../../../assets/styles/custom.scss"
 import popoverStyle from "../../components/styles/popover.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"


### PR DESCRIPTION
## Summary
- load custom scss from the `assets` directory so site styles override defaults

## Testing
- `nohup npx quartz build --serve &` *(fails: quartz: Permission denied)*
- `npm run link-check` *(fails: quartz: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68c08828fc5c8325b811c0c83227554f