### PR TITLE
fix: load custom styles from assets

### DIFF
--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -5,7 +5,7 @@ import { QuartzEmitterPlugin } from "../types"
 import spaRouterScript from "../../components/scripts/spa.inline"
 // @ts-ignore
 import popoverScript from "../../components/scripts/popover.inline"
-import styles from "../../../assets/styles/custom.scss"
+import styles from "../../styles/custom.scss"
 import popoverStyle from "../../components/styles/popover.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1,14 +1,1 @@
-@use "./base.scss";
-
-// put your custom CSS here!
-.label-icon {
-    font-size: 48px;
-    text-anchor: middle;
-    dominant-baseline: middle;
-}
-.label-text {
-    fill: white;
-    font-size: 19px;
-    text-anchor: middle;
-    dominant-baseline: middle;
-}
+@forward "../../assets/styles/custom.scss";


### PR DESCRIPTION
## Summary
- ensure build loads custom stylesheet via quartz styles
- forward quartz custom stylesheet to project asset styles for overrides

## Testing
- `nohup npx -y quartz@latest build --serve &` (fails: Failed to emit from plugin `CustomOgImages`)
- `npm run link-check` (fails: Failed to emit from plugin `CustomOgImages`)


------
https://chatgpt.com/codex/tasks/task_e_68c08eaa5bb48325b54542f48f17126f