### PR TITLE
feat: update Quartz base styles

### DIFF
--- a/assets/styles/custom.scss
+++ b/assets/styles/custom.scss
@@ -1,0 +1,14 @@
+@use "../../quartz/styles/base.scss";
+
+// put your custom CSS here!
+.label-icon {
+    font-size: 48px;
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+.label-text {
+    fill: white;
+    font-size: 19px;
+    text-anchor: middle;
+    dominant-baseline: middle;
+}

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -5,7 +5,7 @@ import { QuartzEmitterPlugin } from "../types"
 import spaRouterScript from "../../components/scripts/spa.inline"
 // @ts-ignore
 import popoverScript from "../../components/scripts/popover.inline"
-import styles from "../../styles/custom.scss"
+import styles from "../../../assets/styles/custom.scss"
 import popoverStyle from "../../components/styles/popover.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -1,526 +1,315 @@
-@use "sass:map";
-
-@use "./variables.scss" as *;
 @use "./syntax.scss";
 @use "./callouts.scss";
 
-html {
-  scroll-behavior: smooth;
-  text-size-adjust: none;
-  overflow-x: hidden;
-  width: 100vw;
+/* ==========================================================================
+   Quartz v4 — Elegant Light/Dark theme add‑on (custom.scss)
+   - Цветовые токены через CSS variables
+   - Надёжные селекторы: html[saved-theme="..."]
+   - Минимально инвазивные стили поверх базовой темы
+   ========================================================================== */
+
+/* (1) Быстрый вариант подключения шрифтов через Google Fonts.
+       Для self-host замените блок на @font-face ниже. */
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300..900&family=Lora:ital,wght@0,400..700;1,400..700&display=swap");
+
+/* (1a) Пример self-host (поместите файлы в quartz/static/fonts/):
+@font-face {
+  font-family: "Inter Var";
+  src: url("/static/fonts/Inter-Variable.woff2") format("woff2-variations");
+  font-weight: 300 900;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Lora Var";
+  src: url("/static/fonts/Lora-Variable.woff2") format("woff2-variations");
+  font-weight: 400 700;
+  font-style: normal italic;
+  font-display: swap;
+}
+*/
+
+/* (2) Дизайн‑токены по умолчанию */
+:root {
+  /* Семейства шрифтов */
+  --font-sans: "Inter", "Inter Var", system-ui, -apple-system, "Segoe UI", Roboto,
+               "Noto Sans", "Helvetica Neue", Arial, "Apple Color Emoji",
+               "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  --font-serif: "Lora", "Lora Var", Georgia, "Times New Roman", serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+               "Liberation Mono", "Courier New", monospace;
+
+  /* Радиусы и тени */
+  --radius-sm: 10px;
+  --radius: 12px;
+  --radius-lg: 16px;
+  --shadow-1: 0 1px 2px rgba(0,0,0,.06), 0 8px 24px rgba(0,0,0,.05);
+  --shadow-2: 0 2px 8px rgba(0,0,0,.08), 0 16px 40px rgba(0,0,0,.06);
+
+  /* Интерлиньяж и плотности */
+  --leading: 1.7;
+  --maxw-text: 75ch; /* комфортная ширина текста */
 }
 
-body {
-  margin: 0;
-  box-sizing: border-box;
-  background-color: var(--light);
-  font-family: var(--bodyFont);
-  color: var(--darkgray);
+/* (3) Палитры тем через mixins (SCSS) */
+@mixin theme-light {
+  /* Тёплые нейтралы + яркие акценты (в тренде‑2025):contentReference[oaicite:4]{index=4} */
+  --bg:            #f8f6f3; /* тёплый off‑white */
+  --surface:       #ffffff;
+  --surface-2:     #f3eee6;
+  --text:          #14110f;
+  --muted:         #6b625b;
+  --border:        #e8e2da;
+
+  /* Бренд и ссылки */
+  --brand:         #8b5d3b; /* «mocha»-тёплый */
+  --brand-contrast:#ffffff;
+  --link:          #175cd3; /* доступный синий */
+  --link-hover:    #0b4cbf;
+
+  /* Акценты и коды */
+  --accent-1:      #ffe2bd;
+  --accent-2:      #ff8e6e;
+  --code-bg:       #f5efe7;
+  --code-text:     #1f2937;
+
+  /* Callouts */
+  --callout-note-bg:   #f0f7ff;
+  --callout-note-bd:   #8bb8ff;
+  --callout-tip-bg:    #eef7f2;
+  --callout-tip-bd:    #8bd19a;
+
+  /* Selection */
+  --selection:     #fde6c9;
 }
 
-.text-highlight {
-  background-color: var(--textHighlight);
-  padding: 0 0.1rem;
-  border-radius: 5px;
+@mixin theme-dark {
+  /* Умеренно тёмная палитра + тёплые акценты (актуально в 2025):contentReference[oaicite:5]{index=5} */
+  --bg:            #0f1115;
+  --surface:       #15191e;
+  --surface-2:     #0f1317;
+  --text:          #e9e9e9;
+  --muted:         #a8b0bb;
+  --border:        #2b2f36;
+
+  --brand:         #d1a87a;
+  --brand-contrast:#1a1a1a;
+  --link:          #8ab4ff;
+  --link-hover:    #a4c2ff;
+
+  --accent-1:      #3d2a1a;
+  --accent-2:      #6e2e21;
+  --code-bg:       #0e1420;
+  --code-text:     #d6e2ff;
+
+  --callout-note-bg:   #0f1a2b;
+  --callout-note-bd:   #3f6ecf;
+  --callout-tip-bg:    #0e1f16;
+  --callout-tip-bd:    #2e7d50;
+
+  --selection:     #233555;
 }
+
+/* (4) Применение палитр.
+   Quartz Darkmode выставляет html[saved-theme="light" | "dark"] */
+html[saved-theme="light"] { @include theme-light; }
+html[saved-theme="dark"]  { @include theme-dark; }
+
+/* Fallback, если saved-theme ещё нет — уважаем системное предпочтение */
+@media (prefers-color-scheme: dark) {
+  :root:not([saved-theme]) { @include theme-dark; }
+}
+@media (prefers-color-scheme: light) {
+  :root:not([saved-theme]) { @include theme-light; }
+}
+
+/* ==========================================================================
+   БАЗОВАЯ ТИПОГРАФИКА И КОМПОНЕНТЫ
+   ========================================================================== */
+
+html, body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  line-height: var(--leading);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+main, .page, .content {
+  max-width: var(--maxw-text);
+  margin-inline: auto;
+}
+
+/* Заголовки — элегантная засечковая гарнитура (тренд контрастных пар serif+sans):contentReference[oaicite:7]{index=7} */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-serif);
+  letter-spacing: 0.01em;
+  color: var(--text);
+}
+h1 { font-weight: 700; line-height: 1.2; margin: 1.2em 0 .4em; }
+h2 { font-weight: 700; line-height: 1.25; margin: 1.2em 0 .5em; }
+h3 { font-weight: 600; line-height: 1.3; margin: 1.1em 0 .5em; }
+
+/* Параграфы/списки */
+p { margin: .85rem 0; }
+ul, ol { padding-inline-start: 1.2rem; }
+li + li { margin-top: .25rem; }
+
+/* Ссылки — премиальная подчеркивание/цвета */
+a {
+  color: var(--link);
+  text-decoration: underline;
+  text-decoration-thickness: .08em;
+  text-underline-offset: .18em;
+  transition: color .15s ease, text-decoration-color .15s ease, background-size .2s ease;
+}
+a:hover {
+  color: var(--link-hover);
+  text-decoration-color: currentColor;
+}
+
+/* Кнопко‑ссылки и <button> — мягкие радиусы и тёплый бренд */
+button, .btn, a[role="button"] {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--brand);
+  color: var(--brand-contrast);
+  padding: .55rem .9rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-1);
+  font-weight: 600;
+}
+button:hover, .btn:hover, a[role="button"]:hover {
+  filter: saturate(1.05) brightness(1.02);
+}
+button:focus-visible, .btn:focus-visible, a[role="button"]:focus-visible,
+a:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--link) 60%, transparent);
+  outline-offset: 2px;
+  border-radius: var(--radius);
+}
+
+/* Тумблер тёмной темы (в Quartz это checkbox с id=darkmode-toggle) */
+#darkmode-toggle {
+  accent-color: var(--brand);
+}
+
+/* Блок‑цитаты */
+blockquote {
+  margin: 1rem 0;
+  padding: .85rem 1rem;
+  background: color-mix(in oklab, var(--surface) 85%, var(--brand) 15%);
+  border-left: 3px solid var(--brand);
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+/* Код */
+code, kbd, pre, samp { font-family: var(--font-mono); }
+code {
+  background: var(--code-bg);
+  color: var(--code-text);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) - 4px);
+  padding: .12rem .35rem;
+}
+pre {
+  background: var(--code-bg);
+  color: var(--code-text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: .9rem 1rem;
+  overflow: auto;
+  box-shadow: var(--shadow-1);
+}
+pre code { border: 0; padding: 0; background: transparent; }
+
+/* Таблицы */
+table {
+  border-collapse: collapse;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+thead th {
+  background: var(--surface-2);
+  font-weight: 700;
+}
+td, th {
+  padding: .6rem .7rem;
+  border-bottom: 1px solid var(--border);
+}
+tbody tr:nth-child(2n) {
+  background: color-mix(in oklab, var(--surface) 92%, black 8%);
+}
+
+/* Списки задач */
+input[type="checkbox"] { accent-color: var(--brand); }
+
+/* Подсветка выделения */
 ::selection {
-  background: color-mix(in srgb, var(--tertiary) 60%, rgba(255, 255, 255, 0));
-  color: var(--darkgray);
+  background: var(--selection);
 }
 
-p,
-ul,
-text,
-a,
-tr,
-td,
-li,
-ol,
-ul,
-.katex,
-.math,
-.typst-doc,
-.typst-doc * {
-  color: var(--darkgray);
-  fill: var(--darkgray);
-  hyphens: auto;
+/* Карточные/вспомогательные контейнеры (побочный тонкий слой «премиальности») */
+.card, .popover, .search-panel, .aside, .callout {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-1);
 }
 
-p,
-ul,
-text,
-a,
-li,
-ol,
-ul,
-.katex,
-.math,
-.typst-doc,
-.typst-doc * {
-  overflow-wrap: anywhere;
-  /* tr and td removed from list of selectors for overflow-wrap, allowing them to use default 'normal' property value */
+/* Callouts: базовый тон + два примера переопределений.
+   Quartz позволяет задавать цвета callout’ов прямо в custom.scss */
+.callout { --color: var(--text); --border: var(--border); --bg: var(--surface); }
+.callout[data-callout="note"] {
+  --color: var(--text);
+  --border: var(--callout-note-bd);
+  --bg: var(--callout-note-bg);
+}
+.callout[data-callout="tip"] {
+  --color: var(--text);
+  --border: var(--callout-tip-bd);
+  --bg: var(--callout-tip-bg);
 }
 
-.math {
-  &.math-display {
-    text-align: center;
-  }
+/* Блоки с ярким контрастом (акцентные секции). Вдохновлено трендом «контрастных блоков»:contentReference[oaicite:9]{index=9} */
+.section-contrast {
+  background: linear-gradient(180deg, var(--surface) 0%, color-mix(in oklab, var(--surface-2) 70%, var(--brand) 30%) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: clamp(1rem, 3vw, 2rem);
+  box-shadow: var(--shadow-2);
+}
+
+/* Мелкие микровзаимодействия без перегруза: более «премиальные» hover‑состояния */
+a, button, .btn { transition: background-color .2s, color .2s, filter .2s, transform .08s; }
+button:active, .btn:active { transform: translateY(1px); }
+
+/* ==========================================================================
+   Дополнительные компоненты Quartz
+   ========================================================================== */
+
+.math.math-display {
+  text-align: center;
 }
 
 article {
   > mjx-container.MathJax,
   blockquote > div > mjx-container.MathJax {
     display: flex;
+
     > svg {
       margin-left: auto;
       margin-right: auto;
     }
   }
+
   blockquote > div > mjx-container.MathJax > svg {
     margin-top: 1rem;
     margin-bottom: 1rem;
   }
-}
-
-strong {
-  font-weight: $semiBoldWeight;
-}
-
-a {
-  font-weight: $semiBoldWeight;
-  text-decoration: none;
-  transition: color 0.2s ease;
-  color: var(--secondary);
-
-  &:hover {
-    color: var(--tertiary);
-  }
-
-  &.internal {
-    text-decoration: none;
-    background-color: var(--highlight);
-    padding: 0 0.1rem;
-    border-radius: 5px;
-    line-height: 1.4rem;
-
-    &.broken {
-      color: var(--secondary);
-      opacity: 0.5;
-      transition: opacity 0.2s ease;
-      &:hover {
-        opacity: 0.8;
-      }
-    }
-
-    &:has(> img) {
-      background-color: transparent;
-      border-radius: 0;
-      padding: 0;
-    }
-    &.tag-link {
-      &::before {
-        content: "#";
-      }
-    }
-  }
-
-  &.external .external-icon {
-    height: 1ex;
-    margin: 0 0.15em;
-
-    > path {
-      fill: var(--dark);
-    }
-  }
-}
-
-.flex-component {
-  display: flex;
-}
-
-.desktop-only {
-  display: initial;
-  &.flex-component {
-    display: flex;
-  }
-  @media all and ($mobile) {
-    &.flex-component {
-      display: none;
-    }
-    display: none;
-  }
-}
-
-.mobile-only {
-  display: none;
-  &.flex-component {
-    display: none;
-  }
-  @media all and ($mobile) {
-    &.flex-component {
-      display: flex;
-    }
-    display: initial;
-  }
-}
-
-.page {
-  max-width: calc(#{map.get($breakpoints, desktop)} + 300px);
-  margin: 0 auto;
-  & article {
-    & > h1 {
-      font-size: 2rem;
-    }
-
-    & li:has(> input[type="checkbox"]) {
-      list-style-type: none;
-      padding-left: 0;
-    }
-
-    & li:has(> input[type="checkbox"]:checked) {
-      text-decoration: line-through;
-      text-decoration-color: var(--gray);
-      color: var(--gray);
-    }
-
-    & li > * {
-      margin-top: 0;
-      margin-bottom: 0;
-    }
-
-    p > strong {
-      color: var(--dark);
-    }
-  }
-
-  & > #quartz-body {
-    display: grid;
-    grid-template-columns: #{map.get($desktopGrid, templateColumns)};
-    grid-template-rows: #{map.get($desktopGrid, templateRows)};
-    column-gap: #{map.get($desktopGrid, columnGap)};
-    row-gap: #{map.get($desktopGrid, rowGap)};
-    grid-template-areas: #{map.get($desktopGrid, templateAreas)};
-
-    @media all and ($tablet) {
-      grid-template-columns: #{map.get($tabletGrid, templateColumns)};
-      grid-template-rows: #{map.get($tabletGrid, templateRows)};
-      column-gap: #{map.get($tabletGrid, columnGap)};
-      row-gap: #{map.get($tabletGrid, rowGap)};
-      grid-template-areas: #{map.get($tabletGrid, templateAreas)};
-    }
-    @media all and ($mobile) {
-      grid-template-columns: #{map.get($mobileGrid, templateColumns)};
-      grid-template-rows: #{map.get($mobileGrid, templateRows)};
-      column-gap: #{map.get($mobileGrid, columnGap)};
-      row-gap: #{map.get($mobileGrid, rowGap)};
-      grid-template-areas: #{map.get($mobileGrid, templateAreas)};
-    }
-
-    @media all and not ($desktop) {
-      padding: 0 1rem;
-    }
-    @media all and ($mobile) {
-      margin: 0 auto;
-    }
-
-    & .sidebar {
-      gap: 2rem;
-      top: 0;
-      box-sizing: border-box;
-      padding: $topSpacing 2rem 2rem 2rem;
-      display: flex;
-      height: 100vh;
-      position: sticky;
-    }
-
-    & .sidebar.left {
-      z-index: 1;
-      grid-area: grid-sidebar-left;
-      flex-direction: column;
-      @media all and ($mobile) {
-        gap: 0;
-        align-items: center;
-        position: initial;
-        display: flex;
-        height: unset;
-        flex-direction: row;
-        padding: 0;
-        padding-top: 2rem;
-      }
-    }
-
-    & .sidebar.right {
-      grid-area: grid-sidebar-right;
-      margin-right: 0;
-      flex-direction: column;
-      @media all and ($mobile) {
-        margin-left: inherit;
-        margin-right: inherit;
-      }
-      @media all and not ($desktop) {
-        position: initial;
-        height: unset;
-        width: 100%;
-        flex-direction: row;
-        padding: 0;
-        & > * {
-          flex: 1;
-          max-height: 24rem;
-        }
-        & > .toc {
-          display: none;
-        }
-      }
-    }
-    & .page-header,
-    & .page-footer {
-      margin-top: 1rem;
-    }
-
-    & .page-header {
-      grid-area: grid-header;
-      margin: $topSpacing 0 0 0;
-      @media all and ($mobile) {
-        margin-top: 0;
-        padding: 0;
-      }
-    }
-
-    & .center > article {
-      grid-area: grid-center;
-    }
-
-    & footer {
-      grid-area: grid-footer;
-    }
-
-    & .center,
-    & footer {
-      max-width: 100%;
-      min-width: 100%;
-      margin-left: auto;
-      margin-right: auto;
-      @media all and ($tablet) {
-        margin-right: 0;
-      }
-      @media all and ($mobile) {
-        margin-right: 0;
-        margin-left: 0;
-      }
-    }
-    & footer {
-      margin-left: 0;
-    }
-  }
-}
-
-.footnotes {
-  margin-top: 2rem;
-  border-top: 1px solid var(--lightgray);
-}
-
-input[type="checkbox"] {
-  transform: translateY(2px);
-  color: var(--secondary);
-  border: 1px solid var(--lightgray);
-  border-radius: 3px;
-  background-color: var(--light);
-  position: relative;
-  margin-inline-end: 0.2rem;
-  margin-inline-start: -1.4rem;
-  appearance: none;
-  width: 16px;
-  height: 16px;
-
-  &:checked {
-    border-color: var(--secondary);
-    background-color: var(--secondary);
-
-    &::after {
-      content: "";
-      position: absolute;
-      left: 4px;
-      top: 1px;
-      width: 4px;
-      height: 8px;
-      display: block;
-      border: solid var(--light);
-      border-width: 0 2px 2px 0;
-      transform: rotate(45deg);
-    }
-  }
-}
-
-blockquote {
-  margin: 1rem 0;
-  border-left: 3px solid var(--secondary);
-  padding-left: 1rem;
-  transition: border-color 0.2s ease;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-thead {
-  font-family: var(--headerFont);
-  color: var(--dark);
-  font-weight: revert;
-  margin-bottom: 0;
-
-  article > & > a[role="anchor"] {
-    color: var(--dark);
-    background-color: transparent;
-  }
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  &[id] > a[href^="#"] {
-    margin: 0 0.5rem;
-    opacity: 0;
-    transition: opacity 0.2s ease;
-    transform: translateY(-0.1rem);
-    font-family: var(--codeFont);
-    user-select: none;
-  }
-
-  &[id]:hover > a {
-    opacity: 1;
-  }
-
-  &:not([id]) > a[role="anchor"] {
-    display: none;
-  }
-}
-
-// typography improvements
-h1 {
-  font-size: 1.75rem;
-  margin-top: 2.25rem;
-  margin-bottom: 1rem;
-}
-
-h2 {
-  font-size: 1.4rem;
-  margin-top: 1.9rem;
-  margin-bottom: 1rem;
-}
-
-h3 {
-  font-size: 1.12rem;
-  margin-top: 1.62rem;
-  margin-bottom: 1rem;
-}
-
-h4,
-h5,
-h6 {
-  font-size: 1rem;
-  margin-top: 1.5rem;
-  margin-bottom: 1rem;
-}
-
-figure[data-rehype-pretty-code-figure] {
-  margin: 0;
-  position: relative;
-  line-height: 1.6rem;
-  position: relative;
-
-  & > [data-rehype-pretty-code-title] {
-    font-family: var(--codeFont);
-    font-size: 0.9rem;
-    padding: 0.1rem 0.5rem;
-    border: 1px solid var(--lightgray);
-    width: fit-content;
-    border-radius: 5px;
-    margin-bottom: -0.5rem;
-    color: var(--darkgray);
-  }
-
-  & > pre {
-    padding: 0;
-  }
-}
-
-pre {
-  font-family: var(--codeFont);
-  padding: 0 0.5rem;
-  border-radius: 5px;
-  overflow-x: auto;
-  border: 1px solid var(--lightgray);
-  position: relative;
-
-  &:has(> code.mermaid) {
-    border: none;
-  }
-
-  & > code {
-    background: none;
-    padding: 0;
-    font-size: 0.85rem;
-    counter-reset: line;
-    counter-increment: line 0;
-    display: grid;
-    padding: 0.5rem 0;
-    overflow-x: auto;
-
-    & [data-highlighted-chars] {
-      background-color: var(--highlight);
-      border-radius: 5px;
-    }
-
-    & > [data-line] {
-      padding: 0 0.25rem;
-      box-sizing: border-box;
-      border-left: 3px solid transparent;
-
-      &[data-highlighted-line] {
-        background-color: var(--highlight);
-        border-left: 3px solid var(--secondary);
-      }
-
-      &::before {
-        content: counter(line);
-        counter-increment: line;
-        width: 1rem;
-        margin-right: 1rem;
-        display: inline-block;
-        text-align: right;
-        color: rgba(115, 138, 148, 0.6);
-      }
-    }
-
-    &[data-line-numbers-max-digits="2"] > [data-line]::before {
-      width: 2rem;
-    }
-
-    &[data-line-numbers-max-digits="3"] > [data-line]::before {
-      width: 3rem;
-    }
-  }
-}
-
-code {
-  font-size: 0.9em;
-  color: var(--dark);
-  font-family: var(--codeFont);
-  border-radius: 5px;
-  padding: 0.1rem 0.2rem;
-  background: var(--lightgray);
-}
-
-tbody,
-li,
-p {
-  line-height: 1.6rem;
 }
 
 .table-container {
@@ -545,7 +334,7 @@ p {
 th {
   text-align: left;
   padding: 0.4rem 0.7rem;
-  border-bottom: 2px solid var(--gray);
+  border-bottom: 2px solid var(--border);
 }
 
 td {
@@ -553,7 +342,8 @@ td {
 }
 
 tr {
-  border-bottom: 1px solid var(--lightgray);
+  border-bottom: 1px solid var(--border);
+
   &:last-child {
     border-bottom: none;
   }
@@ -561,7 +351,7 @@ tr {
 
 img {
   max-width: 100%;
-  border-radius: 5px;
+  border-radius: var(--radius);
   margin: 1rem 0;
   content-visibility: auto;
 }
@@ -576,49 +366,13 @@ hr {
   margin: 2rem auto;
   height: 1px;
   border: none;
-  background-color: var(--lightgray);
+  background-color: var(--border);
 }
 
 audio,
 video {
   width: 100%;
-  border-radius: 5px;
-}
-
-.spacer {
-  flex: 2 1 auto;
-}
-
-div:has(> .overflow) {
-  max-height: 100%;
-  overflow-y: hidden;
-}
-
-ul.overflow,
-ol.overflow {
-  max-height: 100%;
-  overflow-y: auto;
-  width: 100%;
-  margin-bottom: 0;
-
-  // clearfix
-  content: "";
-  clear: both;
-
-  & > li.overflow-end {
-    height: 0.5rem;
-    margin: 0;
-  }
-
-  &.gradient-active {
-    mask-image: linear-gradient(to bottom, black calc(100% - 50px), transparent 100%);
-  }
-}
-
-.transclude {
-  ul {
-    padding-left: 1rem;
-  }
+  border-radius: var(--radius);
 }
 
 .katex-display {
@@ -632,7 +386,7 @@ iframe.pdf {
   aspect-ratio: 16 / 9;
   height: 100%;
   width: 100%;
-  border-radius: 5px;
+  border-radius: var(--radius);
 }
 
 .navigation-progress {
@@ -641,7 +395,7 @@ iframe.pdf {
   left: 0;
   width: 0;
   height: 3px;
-  background: var(--secondary);
+  background: var(--link);
   transition: width 0.2s ease;
   z-index: 9999;
 }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -1,6 +1,3 @@
-@use "./syntax.scss";
-@use "./callouts.scss";
-
 /* ==========================================================================
    Quartz v4 — Elegant Light/Dark theme add‑on (custom.scss)
    - Цветовые токены через CSS variables
@@ -11,6 +8,8 @@
 /* (1) Быстрый вариант подключения шрифтов через Google Fonts.
        Для self-host замените блок на @font-face ниже. */
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300..900&family=Lora:ital,wght@0,400..700;1,400..700&display=swap");
+@import "./syntax.scss";
+@import "./callouts.scss";
 
 /* (1a) Пример self-host (поместите файлы в quartz/static/fonts/):
 @font-face {


### PR DESCRIPTION
## Summary
- adopt light/dark CSS variable tokens as base theme
- add typography and component tweaks for Quartz

## Testing
- `nohup npx quartz build --serve >/tmp/quartz_build.log 2>&1 &`
- `npm run link-check` *(fails: fetch failed in CustomOgImages)*

------
https://chatgpt.com/codex/tasks/task_e_68c0953d2da0832588d8f6501fe37569