### PR TITLE
fix(styles): remove cross-media-query Sass extends

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1,4 +1,24 @@
 @use "./base.scss";
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300..900&family=Lora:ital,wght@0,400..700;1,400..700&display=swap");
+
+/* (1) Быстрый вариант подключения шрифтов через Google Fonts.
+       Для self-host замените блок на @font-face ниже. */
+/* (1a) Пример self-host (поместите файлы в quartz/static/fonts/):
+@font-face {
+  font-family: "Inter Var";
+  src: url("/static/fonts/Inter-Variable.woff2") format("woff2-variations");
+  font-weight: 300 900;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Lora Var";
+  src: url("/static/fonts/Lora-Variable.woff2") format("woff2-variations");
+  font-weight: 400 700;
+  font-style: normal italic;
+  font-display: swap;
+}
+*/
 
 // put your custom CSS here!
 .label-icon {
@@ -19,27 +39,6 @@
    - Надёжные селекторы: html[saved-theme="..."]
    - Минимально инвазивные стили поверх базовой темы
    ========================================================================== */
-
-/* (1) Быстрый вариант подключения шрифтов через Google Fonts.
-       Для self-host замените блок на @font-face ниже. */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300..900&family=Lora:ital,wght@0,400..700;1,400..700&display=swap");
-
-/* (1a) Пример self-host (поместите файлы в quartz/static/fonts/):
-@font-face {
-  font-family: "Inter Var";
-  src: url("/static/fonts/Inter-Variable.woff2") format("woff2-variations");
-  font-weight: 300 900;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: "Lora Var";
-  src: url("/static/fonts/Lora-Variable.woff2") format("woff2-variations");
-  font-weight: 400 700;
-  font-style: normal italic;
-  font-display: swap;
-}
-*/
 
 /* (2) Дизайн‑токены по умолчанию */
 :root {

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -64,7 +64,7 @@
 }
 
 /* (3) Палитры тем через плейсхолдеры (SCSS) */
-%theme-light {
+@mixin theme-light {
   /* Тёплые нейтралы + яркие акценты (в тренде‑2025):contentReference[oaicite:4]{index=4} */
   --bg:            #f8f6f3; /* тёплый off‑white */
   --surface:       #ffffff;
@@ -95,7 +95,7 @@
   --selection:     #fde6c9;
 }
 
-%theme-dark {
+@mixin theme-dark {
   /* Умеренно тёмная палитра + тёплые акценты (актуально в 2025):contentReference[oaicite:5]{index=5} */
   --bg:            #0f1115;
   --surface:       #15191e;
@@ -124,15 +124,15 @@
 
 /* (4) Применение палитр.
    Quartz Darkmode выставляет html[saved-theme="light" | "dark"] */
-html[saved-theme="light"] { @extend %theme-light; }
-html[saved-theme="dark"]  { @extend %theme-dark; }
+html[saved-theme="light"] { @include theme-light; }
+html[saved-theme="dark"]  { @include theme-dark; }
 
 /* Fallback, если saved-theme ещё нет — уважаем системное предпочтение */
 @media (prefers-color-scheme: dark) {
-  :root:not([saved-theme]) { @extend %theme-dark; }
+  :root:not([saved-theme]) { @include theme-dark; }
 }
 @media (prefers-color-scheme: light) {
-  :root:not([saved-theme]) { @extend %theme-light; }
+  :root:not([saved-theme]) { @include theme-light; }
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- replace placeholder selectors with mixins and `@include` to avoid Sass `@extend` across media queries

## Testing
- `npx quartz build` *(fails: CustomOgImages fetch failed)*
- `nohup npx quartz build --serve &` *(fails: CustomOgImages fetch failed)*
- `npm run link-check` *(fails: CustomOgImages fetch failed)*
- `npm test`
- `npm run check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a2751c808325b96cf8d5b62c4c87